### PR TITLE
Addresses undefined index notices if action key for filter settings is not set.

### DIFF
--- a/islandora_context.module
+++ b/islandora_context.module
@@ -510,6 +510,9 @@ function islandora_context_islandora_derivative_alter(&$derivatives, AbstractObj
   // Implement the reaction.
   if ($plugin = context_get_plugin('reaction', 'islandora_context_reaction_filter_derivatives')) {
     $filter_settings = $plugin->execute();
+    if(!isset($filter_settings['action'])) {
+      $filter_settings['action'] = NULL;
+    }
     if ($filter_settings['action'] == 'include') {
       foreach ($derivatives as $key => $derivative) {
         if (!in_array($derivative['destination_dsid'], $filter_settings['dsids'])) {


### PR DESCRIPTION
# What does this pull request do?

In some cases,  `$filter_settings['action']` may not be set and a PHP undefined index notice will be generated as a result.   This pull request adds a check to determine if `$filter_settings['action']` is set and if not, assigns it a value of `NULL`.

# How should this be tested?

For those who see the PHP notices, after pulling this change, they should no longer see undefined index notices for `$filter_settings['action']`  from inslandora_context.module.




