### PR TITLE
Accesses array $markup by key to get the expected string.

### DIFF
--- a/islandora_context.module
+++ b/islandora_context.module
@@ -322,7 +322,7 @@ function islandora_context_islandora_view_object_alter(&$object, &$rendered) {
   if ($plugin = context_get_plugin('reaction', 'islandora_context_reaction_insert_text')) {
     if ($markup = $plugin->execute()) {
       if (isset($rendered[NULL])) {
-        $rendered[NULL]['#markup'] = $rendered[NULL]['#markup'] . $markup;
+        $rendered[NULL]['#markup'] = $rendered[NULL]['#markup'] . $markup['#markup'];
       }
     }
   }


### PR DESCRIPTION
# Github issue

Not sure there is an issue for this yet - search for 'insert' in the issue queue returned nothing.

* Other Relevant Links (Google Groups discussion, related pull requests, etc.)

# What does this pull request do?

Accesses the array key '#markup' to get the string value, rather than letting php try to concatenate an array.

# What's new?

# How should this be tested?

on a clean install of islandora + islandora_context set up an insert text reaction, setting the text to be inserted to be an arbitrary string.

# Additional Notes:

Attached screenshots show the error message, the context config, and the string 'Array' appended at the bottom of the markup.

I've just been playing with this for a few minutes, so it's likely that I have gone about this hello world test a little backward. Looking forward to getting deeper into this in the next few days.

# Interested parties
@mjordan
![screenshot - 05102017 - 07 24 58 pm](https://cloud.githubusercontent.com/assets/1117356/25926865/725db662-35b7-11e7-8fa0-8559d79ef0d3.png)
![screenshot - 05102017 - 07 24 34 pm](https://cloud.githubusercontent.com/assets/1117356/25926867/726137ba-35b7-11e7-881e-e585b1b5a547.png)
![screenshot - 05102017 - 07 24 20 pm](https://cloud.githubusercontent.com/assets/1117356/25926866/725f9d7e-35b7-11e7-8532-4f16e3a0fbec.png)
